### PR TITLE
fix a reported bug of PTM_normalization

### DIFF
--- a/R/normalization.R
+++ b/R/normalization.R
@@ -172,6 +172,7 @@ PTM_normalization <- function(ptm_se, se, print_progress=F) {
   tl <- nrow(psite_df)* length(inter_sample)
   all_psite <- rep(0, tl)
   all_prot <- rep(0, tl)
+  all_index <- rep(NA_character_, tl)
   record_pos_start <- rep(0, length(inter_prot))
   record_pos_end <- rep(0, length(inter_prot))
   prot1 <- inter_prot[1]
@@ -181,11 +182,13 @@ PTM_normalization <- function(ptm_se, se, print_progress=F) {
 
   phos_d = c(t(as.matrix(sel_phos1[,inter_sample])))
   prot_d = rep(c(as.matrix(prot_sort_df[1, inter_sample])), nrow(sel_phos1))
+  index_d = rep(sel_phos1$Index, each = length(inter_sample))
 
   record_pos_start[1] = 1
   record_pos_end[1] = length(phos_d)
   all_psite[record_pos_start[1]: record_pos_end[1]] = phos_d
   all_prot[record_pos_start[1]: record_pos_end[1]] = prot_d
+  all_index[record_pos_start[1]: record_pos_end[1]] = index_d
 
   for(i in 2:length(inter_prot))
   {
@@ -194,10 +197,12 @@ PTM_normalization <- function(ptm_se, se, print_progress=F) {
       dplyr::filter(ProteinID == prot)
     phos_d = c(t(as.matrix(sel_phos[,inter_sample])))
     prot_d = rep(c(as.matrix(prot_sort_df[i, inter_sample])), nrow(sel_phos))
+    index_d = rep(sel_phos$Index, each = length(inter_sample))
     record_pos_start[i] = record_pos_end[i-1]+1
     record_pos_end[i] = record_pos_start[i]-1+ length(phos_d)
     all_psite[record_pos_start[i]: record_pos_end[i]] = phos_d
     all_prot[record_pos_start[i]: record_pos_end[i]] = prot_d
+    all_index[record_pos_start[i]: record_pos_end[i]] = index_d
     if(print_progress & i%%1000 ==0) {
       print(paste0(i, "/", length(inter_prot),"\n"))
     }
@@ -208,13 +213,14 @@ PTM_normalization <- function(ptm_se, se, print_progress=F) {
 
   p_df = data.frame(phospho = all_psite, prot = all_prot,
                     caseID = rep(inter_sample, nrow(psite_df)),
-                    Index = rep(psite_df$Index, each = length(inter_sample)),
+                    Index = all_index,
                     stringsAsFactors = F)%>%
     na.omit()
 
   rm(psite_df)
   rm(all_psite)
   rm(all_prot)
+  rm(all_index)
 
   p = lm(phospho~prot, data = p_df)
 


### PR DESCRIPTION
the bug was that Index in the final p_df was taken directly from psite_df$Index, but all_psite/all_prot are built by iterating over inter_prot (looping per-protein through sel_phos), which doesn't preserve psite_df's original row order. That mismatch meant psite indices could be paired with the wrong phospho/protein values. The fix builds all_index in lockstep with all_psite/all_prot during the same per-protein loop, then uses that for Index instead of the original psite_df$Index.

Shorter version:
all_psite and all_prot are built by looping over inter_prot, which can reorder rows relative to psite_df. The old code still pulled Index directly from psite_df$Index, so some psites ended up paired with the wrong phospho/protein values in p_df. Track Index alongside all_psite/all_prot in the same loop (all_index) so the mapping stays correct.